### PR TITLE
Some small tweaks and such

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,7 +14,7 @@ pg_ctl status 2&> /dev/null
 pg_status=$?
 if [ "$pg_status" = "1" ]
 then
-    pg_ctl start &
+    pg_ctl start &> /dev/null
     echo 'Waiting for pg to start...'
     sleep 5;
 fi
@@ -37,7 +37,7 @@ results=$?
 # Cleanup postgres.
 if [ $pg_status -eq 1 ]
 then
-    pg_ctl stop &
+    pg_ctl stop &> /dev/null
 fi
 
 exit $results;

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -32,7 +32,7 @@ psql -U cloud -d ${DATABASE_NAME} -a -f snapCloud/cloud.sql > /dev/null
 
 echo 'Running tests...'
 # Run the tests in the spec directory with resty nginx libraries
-cd snapCloud && resty -I ../spec/ ../resty_busted.lua ../spec
+cd snapCloud && resty -I ../spec/ ../resty_busted.lua ../spec $@
 results=$?
 
 # Cleanup postgres.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -16,7 +16,7 @@ if [ "$pg_status" = "1" ]
 then
     pg_ctl start &> /dev/null
     echo 'Waiting for pg to start...'
-    sleep 5;
+    sleep 1;
 fi
 
 # lapis config will pull this in as the db name
@@ -30,6 +30,7 @@ createdb -O ${DATABASE_USERNAME} ${DATABASE_NAME}
 # load the schema into the test db
 psql -U cloud -d ${DATABASE_NAME} -a -f snapCloud/cloud.sql > /dev/null
 
+echo 'Running tests...'
 # Run the tests in the spec directory with resty nginx libraries
 cd snapCloud && resty -I ../spec/ ../resty_busted.lua ../spec
 results=$?

--- a/spec/api_spec.lua
+++ b/spec/api_spec.lua
@@ -179,8 +179,6 @@ describe('The user endpoint', function()
         assert.is.truthy(body.errors[1]:find('do not have permission'))
     end)
 
-    --[[ IN_DEV waiting on pr to be merged so that use is queried before delete is attempted
-
     it('an admin can DELETE a user', function()
         test_util.create_user(username, api_password)
         test_util.create_user(admin_user, admin_password, {isadmin = true})
@@ -196,8 +194,6 @@ describe('The user endpoint', function()
         assert.is.truthy(body.message:find(username) and body.message:find('removed'))
         assert.is_nil(test_util.retrieve_user(username))
     end)
-
-    ]]
 
     it('a basic user cannot DELETE a user', function()
         local second_u = username .. '_two'

--- a/spec/api_spec.lua
+++ b/spec/api_spec.lua
@@ -183,7 +183,7 @@ describe('The user endpoint', function()
         test_util.create_user(username, api_password)
         test_util.create_user(admin_user, admin_password, {isadmin = true})
 
-        local session = test_util.create_session(admin_user, admin_password)
+        local session = test_util.create_session(admin_user, admin_password, false)
 
         local status, body, headers = session:request('/users/' .. username, {
             method = 'DELETE',

--- a/spec/api_spec.lua
+++ b/spec/api_spec.lua
@@ -107,7 +107,7 @@ describe('The login endpoint', function()
         assert.same(404, status)
         assert.is.truthy(error:find('No user') and error:find('exists'))
     end)
-    
+
     it('POST should error for a non-verified user with no token', function()
         test_util.create_user(username, api_password, {verified = false})
 
@@ -280,7 +280,6 @@ describe('The newpassword endpoint', function()
         local status, body, headers = update_password(session, api_password, nil)
 
         assert.same(400, status)
-        print(body.errors[1])
         assert.is.truthy(body.errors[1]:find('newpassword'))
     end)
 


### PR DESCRIPTION
* enable delete user test
* have the test script start and stop pg
    * sometimes you might want to test without starting lapis
* enable you to pass busted flags to run_tests
    * `./run_tests.sh -t only`. (You can add a `#only` to the end of single spec to run just that one. Or use any name.)